### PR TITLE
Convert feedList to an array if not already an array

### DIFF
--- a/src/hooks/useSDKSocket.ts
+++ b/src/hooks/useSDKSocket.ts
@@ -14,7 +14,7 @@ export type SDKSocketHookOptions = {
 };
 
 export const useSDKSocket = ({ account, env = '', chainId, isCAIP }: SDKSocketHookOptions) => {
-
+  
   const [pushSDKSocket, setPushSDKSocket] = useState<any>(null);
   const [feedsSinceLastConnection, setFeedsSinceLastConnection] = useState<any>([]);
   const [isSDKSocketConnected, setIsSDKSocketConnected] = useState(pushSDKSocket?.connected);
@@ -61,19 +61,19 @@ export const useSDKSocket = ({ account, env = '', chainId, isCAIP }: SDKSocketHo
     if (pushSDKSocket) {
       addSocketEvents();
     }
-
+  
     return () => {
       if (pushSDKSocket) {
         removeSocketEvents();
       }
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pushSDKSocket]);
 
 
   /**
    * Whenever the requisite params to create a connection object change
-   *  - disconnect the old connection
+   *  - disconnect the old connection 
    *  - create a new connection object
    */
   useEffect(() => {
@@ -82,7 +82,7 @@ export const useSDKSocket = ({ account, env = '', chainId, isCAIP }: SDKSocketHo
         // console.log('=================>>> disconnection in the hook');
         pushSDKSocket?.disconnect();
       }
-
+      
       const connectionObject = createSocketConnection({
         user: account,
         env,
@@ -92,14 +92,14 @@ export const useSDKSocket = ({ account, env = '', chainId, isCAIP }: SDKSocketHo
       // set to context
       setPushSDKSocket(connectionObject);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [account, env, chainId, isCAIP]);
 
 
   return {
-    pushSDKSocket,
-    isSDKSocketConnected,
-    feedsSinceLastConnection,
-    lastConnectionTimestamp
+      pushSDKSocket,
+      isSDKSocketConnected,
+      feedsSinceLastConnection,
+      lastConnectionTimestamp
   }
 };

--- a/src/hooks/useSDKSocket.ts
+++ b/src/hooks/useSDKSocket.ts
@@ -14,7 +14,7 @@ export type SDKSocketHookOptions = {
 };
 
 export const useSDKSocket = ({ account, env = '', chainId, isCAIP }: SDKSocketHookOptions) => {
-  
+
   const [pushSDKSocket, setPushSDKSocket] = useState<any>(null);
   const [feedsSinceLastConnection, setFeedsSinceLastConnection] = useState<any>([]);
   const [isSDKSocketConnected, setIsSDKSocketConnected] = useState(pushSDKSocket?.connected);
@@ -41,10 +41,11 @@ export const useSDKSocket = ({ account, env = '', chainId, isCAIP }: SDKSocketHo
        * We receive a feed list which has 1 item.
        */
       console.log("\n\n\n\neachFeed event: ", feedList);
-
+      // Convert feedList to an array if it's not an array
+      const feedArray = Array.isArray(feedList) ? feedList : [feedList];
       // do stuff with data
       setFeedsSinceLastConnection((oldFeeds: any) => {
-        return [...oldFeeds, ...feedList]
+        return [...oldFeeds, ...feedArray]
       });
     });
   };
@@ -60,19 +61,19 @@ export const useSDKSocket = ({ account, env = '', chainId, isCAIP }: SDKSocketHo
     if (pushSDKSocket) {
       addSocketEvents();
     }
-  
+
     return () => {
       if (pushSDKSocket) {
         removeSocketEvents();
       }
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pushSDKSocket]);
 
 
   /**
    * Whenever the requisite params to create a connection object change
-   *  - disconnect the old connection 
+   *  - disconnect the old connection
    *  - create a new connection object
    */
   useEffect(() => {
@@ -81,7 +82,7 @@ export const useSDKSocket = ({ account, env = '', chainId, isCAIP }: SDKSocketHo
         // console.log('=================>>> disconnection in the hook');
         pushSDKSocket?.disconnect();
       }
-      
+
       const connectionObject = createSocketConnection({
         user: account,
         env,
@@ -91,14 +92,14 @@ export const useSDKSocket = ({ account, env = '', chainId, isCAIP }: SDKSocketHo
       // set to context
       setPushSDKSocket(connectionObject);
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [account, env, chainId, isCAIP]);
 
 
   return {
-      pushSDKSocket,
-      isSDKSocketConnected,
-      feedsSinceLastConnection,
-      lastConnectionTimestamp
+    pushSDKSocket,
+    isSDKSocketConnected,
+    feedsSinceLastConnection,
+    lastConnectionTimestamp
   }
 };


### PR DESCRIPTION
This PR addresses an issue where the feedList received from the EVENTS.USER_FEEDS event may not always be an array. If feedList is not an array, it causes an "Uncaught TypeError: feedList is not iterable" error when attempting to spread it in the setFeedsSinceLastConnection function.

To fix this issue, the following change has been made:

This ensures that feedList is always treated as an array, preventing the TypeError and allowing the component to function correctly.
```
// Convert feedList to an array if it's not an array
const feedArray = Array.isArray(feedList) ? feedList : [feedList];
// do stuff with data
setFeedsSinceLastConnection((oldFeeds: any) => {
  return [...oldFeeds, ...feedArray]
});
```