### PR TITLE
Adding version ethers@^5.6.9 in dependencies indication to avoid ethers V6 breaking changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ yarn add styled-components
 ```
 
 2. Since its a dApp, the following are the **web3** dependencies that you can install for wallet connection
+   **Latest version of Ethers (v6) introduces some breaking changes, for best results use Ethers v5 (ethers@^5.6)**
 ```bash
  yarn add ethers@5.6.9
 ```
-**Latest version of Ethers (v6) introduces some breaking changes, for best results use Ethers v5 (ethers@^5.6)**
 
 3. Needed only if you are using [web3-react](https://github.com/Uniswap/web3-react). You are free to use any other React based web3 solution.
 ```bash

--- a/README.md
+++ b/README.md
@@ -38,8 +38,9 @@ yarn add styled-components
 
 2. Since its a dApp, the following are the **web3** dependencies that you can install for wallet connection
 ```bash
- yarn add ethers
+ yarn add ethers@5.6.9
 ```
+**Latest version of Ethers (v6) introduces some breaking changes, for best results use Ethers v5 (ethers@^5.6)**
 
 3. Needed only if you are using [web3-react](https://github.com/Uniswap/web3-react). You are free to use any other React based web3 solution.
 ```bash


### PR DESCRIPTION
Adding note (and version) to people following dependencies intallation to install version ethers@^5.6.9 to avoid ethers V6 breaking changes, this according to what tells the docs [here ](https://docs.push.org/developers/developer-tooling/push-sdk/sdk-packages-details/epnsproject-sdk-restapi/for-notification/opt-in-and-opt-out ) 


![Screenshot from 2023-04-22 11-15-59](https://user-images.githubusercontent.com/23249805/233795414-e2d3f5ef-f179-4bcb-a2ff-65475a46627c.png)
